### PR TITLE
fix: Relative Path Issue for CV Links

### DIFF
--- a/layout/selfIntro/selfIntro.html
+++ b/layout/selfIntro/selfIntro.html
@@ -90,7 +90,7 @@
         </p>
         <p class="selfIntroLinks">
           <a href="mailto:fcrryan173@gmail.com">☘️ Email</a>&nbsp/&nbsp
-          <a href="assets/CV.pdf">🧩 CV</a>&nbsp/&nbsp
+          <a href="../../assets/CV.pdf">🧩 CV</a>&nbsp/&nbsp
           <a href="https://twitter.com/RyanMfer">🌗 Twitter</a>&nbsp/&nbsp
           <a href="https://github.com/RyanFcr">💻 Github</a>&nbsp/&nbsp
           <a href="https://www.youtube.com/channel/UCwoRlsYEg85MAK9_O-qPTiw"


### PR DESCRIPTION
See https://ryanfcr.github.io/layout/selfIntro/selfIntro.html

Change https://ryanfcr.github.io/layout/selfIntro/assets/CV.pdf -> https://ryanfcr.github.io/assets/CV.pdf